### PR TITLE
画像を挿入するキーバインドを追加してみました

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ For latex-itemizer
 |--------------------------------|---------------------------|
 | latex-itemizer:newline-item    | ```Alt         + Enter``` |
 | latex-itemizer:newline-itemize | ```Alt + Shift + Enter``` |
+| latex-itemizer:newline-iamge   | ```Alt + Shift + I    ``` |
 
 
 ## Demo

--- a/keymaps/latex-itemizer.cson
+++ b/keymaps/latex-itemizer.cson
@@ -1,3 +1,4 @@
 '.editor[data-grammar~="latex"]:not([mini])':
   'alt-enter': 'latex-itemizer:newline-item'
   'alt-shift-enter': 'latex-itemizer:newline-itemize'
+  'alt-shift-i': 'latex-itemizer:newline-image'

--- a/lib/latex-itemizer.coffee
+++ b/lib/latex-itemizer.coffee
@@ -3,11 +3,32 @@
 module.exports =
   subscriptions: null
 
+  config:
+    flag_caption:
+      type: 'boolean'
+      default: true
+      title: 'Include caption'
+    flag_label:
+      type: 'boolean'
+      default: true
+      title: 'Include label'
+    img_width:
+      type: 'number'
+      default: 5
+      minimum: 0
+      title: 'Image width [cm]'
+    place_spec:
+      type: 'string'
+      default: 'htbp'
+      title: 'Placement specifier parameter'
+      description: '\\begin{figure}[\'\'placement specifier\'\']'
+
   activate: ->
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.commands.add 'atom-workspace', {
       'latex-itemizer:newline-item'    : => @newline_item()
       'latex-itemizer:newline-itemize' : => @newline_itemize()
+      'latex-itemizer:newline-image' : => @newline_image()
     }
 
   deactivate: ->
@@ -33,3 +54,30 @@ module.exports =
       atom.commands.dispatch view, 'editor:newline'
       editor.insertText('\\end{itemize}')
       cursor.setBufferPosition(pos)
+
+  newline_image: ->
+    editor = atom.workspace.getActiveTextEditor()
+    cursor = editor.getLastCursor()
+    view = atom.views.getView(editor)
+    place_spec = atom.config.get('latex-itemizer.place_spec')
+    img_width = atom.config.get('latex-itemizer.img_width')
+    flag_caption = atom.config.get('latex-itemizer.flag_caption')
+    flag_label = atom.config.get('latex-itemizer.flag_label')
+    editor.transact =>
+        atom.commands.dispatch view, 'editor:newline'
+        editor.insertText("\\begin{figure}[#{place_spec}]")
+        atom.commands.dispatch view, 'editor:newline'
+        editor.insertText('\\centering')
+        atom.commands.dispatch view, 'editor:newline'
+        editor.insertText "\\includegraphics[width=#{img_width}cm]{"
+        pos = cursor.getBufferPosition()
+        editor.insertText('}')
+        if flag_caption
+          atom.commands.dispatch view, 'editor:newline'
+          editor.insertText('\\caption{}')
+        if flag_label
+          atom.commands.dispatch view, 'editor:newline'
+          editor.insertText('\\label{}')
+        atom.commands.dispatch view, 'editor:newline'
+        editor.insertText('\\end{figure}')
+        cursor.setBufferPosition(pos)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "activationCommands": {
     "atom-text-editor[data-grammar~=\"latex\"]": [
       "latex-itemizer:newline-item",
-      "latex-itemizer:newline-itemize"
+      "latex-itemizer:newline-itemize",
+      "latex-itemizer:newline-image"
     ]
   },
   "repository": "https://github.com/horyu/latex-itemizer",


### PR DESCRIPTION
## 追加した内容
<kbd>Alt + Shift + I</kbd>で画像挿入の記述が出るようにしました。

デフォルトの記述：

```
\begin{figure}[htbp]
  \centering
  \includegraphics[width=5cm]{}
  \caption{}
  \label{}
\end{figure}
```

表示位置、画像のサイズ、キャプションとラベルの有無はAtomの設定から変更できます。

## P.S.
プルリクやってみたかった。